### PR TITLE
Changed login algorithm checking to use `pbkdf2_sha512` instead of `sha512`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Mako==1.1.4
 marko==1.0.3
 MarkupSafe==2.0.1
 packaging==20.9
+passlib==1.7.4
 pluggy==0.13.1
 py==1.10.0
 pycosat==0.6.3

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,4 +1,4 @@
-from hashlib import sha512
+from passlib.hash import pbkdf2_sha512
 
 from app.models import User
 
@@ -7,9 +7,8 @@ def test_authenticate(app):
     assert User.authenticate('password') is True
     assert User.authenticate('') is False
     with open(app.config['CRED_FILE']) as f:
-        hashed_password = sha512(b'password').hexdigest()
         hashed_password_in_db = f.read()
-        assert hashed_password == hashed_password_in_db
+        assert pbkdf2_sha512.verify('password', hashed_password_in_db) is True
     assert User.authenticate('password') is True
 
 
@@ -17,9 +16,9 @@ def test_change_password(app):
     assert User.change_password('') is False
     assert User.change_password('new password')
     with open(app.config['CRED_FILE']) as f:
-        hashed_password = sha512(b'new password').hexdigest()
         hashed_password_in_db = f.read()
-        assert hashed_password == hashed_password_in_db
+        assert pbkdf2_sha512.verify('new password',
+                                    hashed_password_in_db) is True
     assert User.authenticate('password') is False
     assert User.authenticate('new password') is True
     User.change_password('password') is True


### PR DESCRIPTION
This fixes a potential security vulnerability found by the GitHub code scanning alert:

**Use of a broken or weak cryptographic hashing algorithm on sensitive data (CWE-327, CWE-328, and CWE-916)**

This PR changed the hashing algorithm from `sha512` to `pbkdf2_sha512`. It added `passlib` as a new dependency as it is needed to provide the `pbkdf2_sha512` algorithm.
This PR is will break the previously stored hash. It will revert to the default password. One of many ways to migrate and prevent that from happening is to modify the file `lcat.passwd` manually before updating.