### PR TITLE
Add CSS rules to fix log post title glitch

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -12,6 +12,11 @@
     width: auto !important;
 }
 
+#logTable > * p, .log-title > p {
+    display: inline !important;
+    margin: 0 !important;
+}
+
 .log-box {
     border: 1px dotted black;
     padding: 0.8rem !important;


### PR DESCRIPTION
## Summary
After the previous pull request #12 was merged, I noticed that there is a glitch when a pinned log post is displayed. When a title is rendered as Markdown, it will be wrapped in a `<p>` tag which makes it displayed by default as a block. When a log post is pinned, a `<span>` element containing a pin icon is placed before that `<p>` tag. It then will cause a glitch: pin icon and the title displayed on a different line.

This PR fixes that glitch by adding a few lines of extra CSS rules in the `style.css` file.