### PR TITLE
feat: add a way to limit public log posts

### DIFF
--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -15,7 +15,7 @@
     <form class="w-100">
         <fieldset>
             <label>Keyword:</label>
-            <input type="text" name="keyword" placeholder="7416fc02-58be-..." required autofocus>
+            <input type="text" name="keyword" minlength=5 placeholder="7416fc02-58be-..." required autofocus>
             <button type="submit">Submit</button>
         </fieldset>
     </form>

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -1,5 +1,5 @@
 import marko
-from flask import (Blueprint, render_template, request)
+from flask import (Blueprint, render_template, request, current_app)
 
 from ..models import LogPost
 
@@ -8,19 +8,21 @@ bp = Blueprint('home', __name__)
 
 @bp.route('/')
 def root():
-    log_posts = LogPost.query.order_by(LogPost.is_pinned.desc(),
-                                       LogPost.created.desc()).all()
+    log_posts = LogPost.query.order_by(
+        LogPost.is_pinned.desc(), LogPost.created.desc()).limit(
+            current_app.config.get('MAX_PUBLIC_POSTS')).all()
     return render_template('home.html', log_posts=log_posts)
 
 
 @bp.route('/search')
 def search():
     keyword = request.args.get('keyword')
-    if keyword:
+    if keyword and len(keyword) >= 5:
         log_posts = LogPost.query.filter(
             (LogPost.title.ilike(f'%{keyword}%'))
             | (LogPost.content.ilike(f'%{keyword}%'))
-            | (LogPost.id == keyword)).order_by(LogPost.created.desc()).all()
+            | (LogPost.id == keyword)).order_by(LogPost.created.desc()).limit(
+                current_app.config.get('MAX_PUBLIC_POSTS')).all()
         return render_template('search.html', log_posts=log_posts, search=True)
     return render_template('search.html')
 

--- a/config.py.template
+++ b/config.py.template
@@ -13,3 +13,4 @@ SQLALCHEMY_DATABASE_URI = ''.join([
     'lcat',  # database name
 ])
 CRED_FILE = 'lcat.passwd'
+MAX_PUBLIC_POSTS = 20  # can be None


### PR DESCRIPTION
This PR essentially does the following
things:

1. Add a default configuration parameter
   `MAX_PUBLIC_POSTS`, can be None
2. In the homepage and search page query,
   limit the log posts according to
   `MAX_PUBLIC_POSTS`
3. Limit the search feature to only allow
   keywords with the minimum length of 5
4. Add proper tests

Closes: #22 
Signed-off-by: Faiz Jazadi <me@lcat.dev>