### PR TITLE
fix: show all post if user is authenticated

### DIFF
--- a/app/views/home.py
+++ b/app/views/home.py
@@ -1,5 +1,4 @@
-import marko
-from flask import (Blueprint, render_template, request, current_app)
+from flask import Blueprint, current_app, render_template, request, session
 
 from ..models import LogPost
 
@@ -8,9 +7,11 @@ bp = Blueprint('home', __name__)
 
 @bp.route('/')
 def root():
+    limit = current_app.config.get('MAX_PUBLIC_POSTS')
+    if 'authed' in session:
+        limit = None
     log_posts = LogPost.query.order_by(
-        LogPost.is_pinned.desc(), LogPost.created.desc()).limit(
-            current_app.config.get('MAX_PUBLIC_POSTS')).all()
+        LogPost.is_pinned.desc(), LogPost.created.desc()).limit(limit).all()
     return render_template('home.html', log_posts=log_posts)
 
 

--- a/tests/functional/test_home_bp.py
+++ b/tests/functional/test_home_bp.py
@@ -7,9 +7,20 @@ def test_empty_home(client):
     assert rv.status_code == 200
 
 
+def test_authenticated_home_content(app, authenticated_client, log_post,
+                                    md_log_post):
+    app.config['MAX_PUBLIC_POSTS'] = 1
+
+    rv = authenticated_client.get('/')
+    assert rv.status_code == 200
+    assert rv.data.count(b'">view') > 1
+
+    app.config['MAX_PUBLIC_POSTS'] = None
+
+
 def test_home_content(app, client, log_post, md_log_post, pinned_log_post):
     app.config['MAX_PUBLIC_POSTS'] = 1
-    
+
     rv = client.get('/')
     assert rv.status_code == 200
     assert rv.data.count(b'">view') == 1
@@ -93,7 +104,7 @@ def test_search_log(app, client, log_post, pinned_log_post):
         assert rv.status_code == 200
         assert keyword.encode() in rv.data
 
-    app.config['MAX_PUBLIC_POSTS'] = 0 
+    app.config['MAX_PUBLIC_POSTS'] = 0
     rv = client.get(f'/search?keyword={pinned_log_post.title}')
     assert rv.status_code == 200
     assert rv.data.count(b'">view') == 0


### PR DESCRIPTION
This commit adds an additional patch to the
previous commit. This commit does the
following things:

1. Disabled public post limit if the home page
   is accessed in an authenticated state
2. Added proper tests

Signed-off-by: Faiz Jazadi <me@lcat.dev>