### PR TITLE
feat: automatically reference a log post by id

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,5 +22,6 @@ def create_app(test_config=None):
 
     from .utils import filters
     app.add_template_filter(filters.md_to_html, 'md_to_html')
+    app.add_template_filter(filters.log_id_autoref, 'log_id_autoref')
 
     return app

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,92 +1,103 @@
 @media (max-width: 50rem) {
-    .separator {
-        display: none;
-    }
-    .small {
-        font-size: 0.8rem;
-    }
+  .separator {
+    display: none;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
 }
 
-#logTable_filter>label:nth-child(1)>input:nth-child(1) {
-    display: inline !important;
-    width: auto !important;
+#logTable_filter > label:nth-child(1) > input:nth-child(1) {
+  display: inline !important;
+  width: auto !important;
 }
 
-#logTable > * p, .log-title > p {
-    display: inline !important;
-    margin: 0 !important;
+#logTable > * p,
+.log-title > p {
+  display: inline !important;
+  margin: 0 !important;
 }
 
 .log-box {
-    border: 1px dotted black;
-    padding: 0.8rem !important;
+  border: 1px dotted black;
+  padding: 0.8rem !important;
 }
 
 .ts-wrap {
-    word-wrap: break-word !important;
-    max-width: 5rem;
+  word-wrap: break-word !important;
+  max-width: 5rem;
 }
 
 .small {
-    font-size: normal;
+  font-size: normal;
 }
 
 .alert-box {
-    margin-bottom: 1rem;
-    border: 1px solid black;
-    background-color: antiquewhite;
-    padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid black;
+  background-color: antiquewhite;
+  padding: 1rem;
 }
 
 .dashed-box {
-    padding: 1rem;
-    border-top: 1px dashed black;
+  padding: 1rem;
+  border-top: 1px dashed black;
 }
 
 .non-markdown-content {
-    background: none;
-    margin-bottom: 0;
+  background: none;
+  margin-bottom: 0;
 }
 
 .alert-box ul {
-    margin: 0;
-    padding-left: inherit;
+  margin: 0;
+  padding-left: inherit;
 }
 
 .w-100 {
-    min-width: 100%;
+  min-width: 100%;
 }
 
 .monospaced {
-    font-family: monospace;
-    font-size: 11pt;
+  font-family: monospace;
+  font-size: 11pt;
+}
+
+.log-id-ref {
+    color: inherit !important;
+    text-decoration: underline;
+    text-decoration-style: dotted;
 }
 
 .log-content h1 {
-    margin-top: 1em;
-    font-size: 1.3em;
+  margin-top: 1em;
+  font-size: 1.3em;
 }
 
-.log-content>*:first-child {
-    margin-top: 0;
+.log-content > *:first-child {
+  margin-top: 0;
 }
 
-.log-content>h2, .log-content>h3, .log-content>h5, .log-content>h6 {
-    margin-top: 1em;
-    font-size: 1em;
+.log-content > h2,
+.log-content > h3,
+.log-content > h5,
+.log-content > h6 {
+  margin-top: 1em;
+  font-size: 1em;
 }
 
 textarea.wide {
-    height: 200px !important;
+  height: 200px !important;
 }
 
 h2.log-title {
-    margin-bottom: 0.5em;
+  margin-bottom: 0.5em;
 }
 
-.log-content>p img, .log-content>p picture {
-    float: none;
-    display: block;
-    max-width: 100%;
-    margin: 0 auto;
+.log-content > p img,
+.log-content > p picture {
+  float: none;
+  display: block;
+  max-width: 100%;
+  margin: 0 auto;
 }

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -21,7 +21,7 @@
                     <path fill-rule="evenodd"
                         d="M4.456.734a1.75 1.75 0 012.826.504l.613 1.327a3.081 3.081 0 002.084 1.707l2.454.584c1.332.317 1.8 1.972.832 2.94L11.06 10l3.72 3.72a.75.75 0 11-1.061 1.06L10 11.06l-2.204 2.205c-.968.968-2.623.5-2.94-.832l-.584-2.454a3.081 3.081 0 00-1.707-2.084l-1.327-.613a1.75 1.75 0 01-.504-2.826L4.456.734zM5.92 1.866a.25.25 0 00-.404-.072L1.794 5.516a.25.25 0 00.072.404l1.328.613A4.582 4.582 0 015.73 9.63l.584 2.454a.25.25 0 00.42.12l5.47-5.47a.25.25 0 00-.12-.42L9.63 5.73a4.581 4.581 0 01-3.098-2.537L5.92 1.866z">
                     </path>
-                </svg> {% endif %}{{ log_post.title|md_to_html }}
+                </svg> {% endif %}{{ log_post.title|log_id_autoref|md_to_html }}
             </td>
             <td class="dt-center">
                 <a href="{{ url_for('home.view_log', log_post_id=log_post.id) }}">view</a>
@@ -34,7 +34,7 @@
                 <a href="{{ url_for('admin.edit_log', log_post_id=log_post.id) }}">edit</a>
                 <span class="separator">|</span>
                 <a href="{{ url_for('admin.delete_log', log_post_id=log_post.id) }}"
-                    onclick="return confirm('Are you sure?')">delete</a>
+                    onclick="confirm('Are you sure?')">delete</a>
                 {% endif %}
             </td>
         </tr>

--- a/app/templates/view_log.html
+++ b/app/templates/view_log.html
@@ -2,7 +2,8 @@
 {% block title %}{{ log_post.title }}{% endblock %}
 {% block article %}
 <section>
-    <h2 class="log-title">{{ log_post.title|md_to_html }}</h2>
+    {% set content = content|log_id_autoref %}
+    <h2 class="log-title">{{ log_post.title|log_id_autoref|md_to_html }}</h2>
     <div class="log-content log-box">
         {% if log_post.is_markdown %}
         {{ content|md_to_html }}

--- a/app/utils/filters.py
+++ b/app/utils/filters.py
@@ -1,6 +1,24 @@
+import re
+
 import marko
-from flask import Markup
+from flask import Markup, url_for
+
+from ..models import LogPost
 
 
 def md_to_html(content):
     return Markup(marko.convert(content))
+
+
+def log_id_autoref(content):
+
+    def replace(match):
+        log_id = match.group(1)
+        external_lp = LogPost.query.filter(
+            LogPost.id.ilike(f'{log_id}%')).first()
+        if not external_lp:
+            return log_id
+        url = url_for('home.view_log', log_post_id=external_lp.id)
+        return f'<a class="log-id-ref" href="{url}">{log_id}</a>'
+
+    return re.sub(r'\b([-0-9a-f]{4,})\b', replace, content, re.M | re.I)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -3,3 +3,15 @@ from app.utils import filters
 
 def test_md_to_html():
     assert '<h1>' in filters.md_to_html('# Hello World')
+
+def test_log_id_autoref(app_context, log_post):
+    partial_id = log_post.id[:5]
+    test_list = [
+        f'{partial_id}',
+        f'lorem {partial_id} ipsum',
+        f'{partial_id} ipsum',
+        f'\n{partial_id} lorem'
+    ]
+    for test_str in test_list:
+        with app_context.test_request_context():
+            assert log_post.id in filters.log_id_autoref(test_str)


### PR DESCRIPTION
This PR carries the following changes:

1. Add a new template filter called
   `log_id_autoref` inside the `filters.py` file
2. Import the newly added filter inside the
   `__init__.py` file
3. Use the filter in the templates when displaying
   log content and log title
4. Add tests accordingly

Closes: #16
Signed-off-by: Faiz Jazadi <me@lcat.dev>